### PR TITLE
Implement pop method for PyRange

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ A TypeScript/JavaScript library that brings Python's range functionality to Java
   - [includes()](#includes)
   - [indexOf()](#indexof)
   - [lastIndexOf()](#lastindexof)
+  - [pop()](#pop)
   - [reverse()](#reverse)
 
 - [Advanced Usage](#advanced-usage)
@@ -291,6 +292,18 @@ It works the same as [**`Array.prototype.lastIndexOf`**](https://developer.mozil
 const range = new PyRange(1, 5, 1);  // [1, 2, 3, 4]
 console.log(range.lastIndexOf(3));    // 2
 console.log(range.lastIndexOf(5));    // -1
+```
+
+### pop()
+
+Similar to [**`Array.prototype.pop`**](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/pop),
+this method removes the last value from the range, shortens the range and
+returns that value.
+
+```javascript
+const range = new PyRange(1, 5);  // [1, 2, 3, 4]
+console.log(range.pop());  // 4
+console.log([...range]);   // [1, 2, 3]
 ```
 
 ### reverse()

--- a/examples/array-methods.js
+++ b/examples/array-methods.js
@@ -66,3 +66,8 @@ range.forEach((x) => {
 // 3 is divisible by 3
 // 6 is divisible by 3
 // 9 is divisible by 3
+
+// Pop: Remove the last value
+const popped = range.pop();
+console.log("pop():", popped); // 9
+console.log("After pop:", [...range]); // [1, 2, 3, 4, 5, 6, 7, 8]

--- a/src/py-range.ts
+++ b/src/py-range.ts
@@ -352,6 +352,29 @@ class PyRange implements Iterable<number> {
   }
 
   /**
+   * Removes the last element from the range and returns it.
+   *
+   * This method behaves similarly to `Array.prototype.pop`. It decreases the
+   * `stop` value by the step size, shortens the range length by one, and returns
+   * the removed value. If the range is empty, `undefined` is returned and the
+   * range remains unchanged.
+   *
+   * @returns {number|undefined} The removed last value, or `undefined` if the
+   * range is empty.
+   */
+  pop(): number | undefined {
+    if (this._length === 0) {
+      return undefined;
+    }
+
+    const lastValue = this.at(this._length - 1);
+    this._stop -= this._step;
+    this._length -= 1;
+
+    return lastValue;
+  }
+
+  /**
    * Reverses the order of the elements in this range, returning a new PyRange object.
    * @returns {PyRange} A new PyRange object with the elements in reverse order.
    */

--- a/test/script.test.ts
+++ b/test/script.test.ts
@@ -97,6 +97,16 @@ describe("PyRange", () => {
       expect(range.indexOf(6)).toBe(-1);
       expect(range.lastIndexOf(3)).toBe(2);
     });
+
+    test("pop() 方法", () => {
+      const rangePop = new PyRange(1, 5); // [1,2,3,4]
+      expect(rangePop.pop()).toBe(4);
+      expect([...rangePop]).toEqual([1, 2, 3]);
+
+      const rangeNeg = new PyRange(5, 1, -1); // [5,4,3,2]
+      expect(rangeNeg.pop()).toBe(2);
+      expect([...rangeNeg]).toEqual([5, 4, 3]);
+    });
   });
 
   // 迭代器測試

--- a/types/range-pie.d.ts
+++ b/types/range-pie.d.ts
@@ -26,6 +26,7 @@ declare module "range-pie" {
     includes(value: any): boolean;
     indexOf(value: any): number;
     lastIndexOf(value: any): number;
+    pop(): number | undefined;
     reverse(): PyRange;
 
     [Symbol.iterator](): Iterator<number>;


### PR DESCRIPTION
## Summary
- add `pop()` to PyRange implementation
- document `pop()` in README and type declarations
- showcase `pop()` usage in array-methods example
- add unit tests for `pop()`

## Testing
- `npm test`